### PR TITLE
dist/redhat: drop dependency on pystache

### DIFF
--- a/dist/redhat/scylla-ami.spec
+++ b/dist/redhat/scylla-ami.spec
@@ -1,13 +1,13 @@
-Name:           {{product}}-ami
-Version:        {{version}}
-Release:        {{release}}
+Name:           %{product}-ami
+Version:        %{version}
+Release:        %{release}
 Summary:        Scylla AMI
 Group:          Applications/Databases
 
 License:        AGPLv3
 URL:            http://www.scylladb.com/
-Source0:        %{name}-{{version}}-{{release}}.tar
-Requires:       {{product}} = {{version}} {{product}}-python3 curl
+Source0:        %{name}-%{version}-%{release}.tar
+Requires:       %{product} = %{version} %{product}-python3 curl
 
 BuildArch:      noarch
 


### PR DESCRIPTION
Same as scylladb/scylla#6313, drop dependency on
pystache since it nolong present in Fedora 32.